### PR TITLE
Create GOV.UK Notify client stub and client provider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-hystrix', version: '1.3.4.RELEASE'
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-hystrix-dashboard', version: '1.3.4.RELEASE'
+  compile group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.4.0-RELEASE'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
 }

--- a/src/main/java/uk/gov/hmcts/reform/pbis/ServiceNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/ServiceNotFoundException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.pbis;
+
+public class ServiceNotFoundException extends RuntimeException {
+
+    public ServiceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pbis/notify/NotificationClientProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/notify/NotificationClientProvider.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.reform.pbis.notify;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.pbis.ServiceNotFoundException;
+import uk.gov.hmcts.reform.pbis.config.ApplicationConfig;
+import uk.gov.hmcts.reform.pbis.model.EmailTemplateMapping;
+import uk.gov.service.notify.NotificationClient;
+import uk.gov.service.notify.NotificationClientApi;
+
+@Component
+public class NotificationClientProvider {
+
+    private final Map<String, NotificationClientApi> notificationClientsByService;
+
+    @Autowired
+    public NotificationClientProvider(ApplicationConfig config) {
+        notificationClientsByService = getApiClientsByService(
+            config.getEmailTemplateMappings(),
+            config.getUseNotifyClientStub()
+        );
+    }
+
+    public NotificationClientApi getClient(String service) {
+        if (notificationClientsByService.containsKey(service)) {
+            return notificationClientsByService.get(service);
+        } else {
+            throw new ServiceNotFoundException(
+                String.format("Failed to find Notify API client for service %s", service)
+            );
+        }
+    }
+
+    private Map<String, NotificationClientApi> getApiClientsByService(
+        List<EmailTemplateMapping> emailTemplateMappings,
+        boolean useStub
+    ) {
+        return emailTemplateMappings
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    mapping -> mapping.getService(),
+                    mapping -> getNotificationClient(mapping.getNotifyApiKey(), useStub)
+                )
+            );
+    }
+
+    private NotificationClientApi getNotificationClient(String notifyApiKey, boolean useStub) {
+        if (useStub) {
+            return new NotificationClientStub();
+        } else {
+            return new NotificationClient(notifyApiKey);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pbis/notify/NotificationClientStub.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/notify/NotificationClientStub.java
@@ -1,0 +1,105 @@
+package uk.gov.hmcts.reform.pbis.notify;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.service.notify.Notification;
+import uk.gov.service.notify.NotificationClientApi;
+import uk.gov.service.notify.NotificationClientException;
+import uk.gov.service.notify.NotificationList;
+import uk.gov.service.notify.SendEmailResponse;
+import uk.gov.service.notify.SendLetterResponse;
+import uk.gov.service.notify.SendSmsResponse;
+import uk.gov.service.notify.Template;
+import uk.gov.service.notify.TemplateList;
+import uk.gov.service.notify.TemplatePreview;
+
+
+public class NotificationClientStub implements NotificationClientApi {
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationClientStub.class);
+
+    private static final String UNSUPPORTED_OPERATION_MESSAGE =
+        "Notification client stub doesn't support this method";
+
+    @Override
+    public SendEmailResponse sendEmail(
+        String templateId,
+        String emailAddress,
+        Map<String, String> personalisation,
+        String reference
+    ) throws NotificationClientException {
+        logger.info(
+            String.format(
+                "Sending email to %s. Template ID: %s, reference: %s",
+                emailAddress,
+                templateId,
+                reference
+            )
+        );
+
+        return null;
+    }
+
+    @Override
+    public SendSmsResponse sendSms(
+        String templateId,
+        String phoneNumber,
+        Map<String, String> personalisation,
+        String reference
+    ) throws NotificationClientException {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
+    }
+
+    @Override
+    public SendLetterResponse sendLetter(
+        String templateId,
+        Map<String, String> personalisation,
+        String reference
+    ) throws NotificationClientException {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
+    }
+
+    @Override
+    public Notification getNotificationById(
+        String notificationId
+    ) throws NotificationClientException {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
+    }
+
+    @Override
+    public NotificationList getNotifications(
+        String status,
+        String notificationType,
+        String reference,
+        String olderThanId
+    ) throws NotificationClientException {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
+    }
+
+    @Override
+    public Template getTemplateById(String templateId) throws NotificationClientException {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
+    }
+
+    @Override
+    public Template getTemplateVersion(
+        String templateId, int version
+    ) throws NotificationClientException {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
+    }
+
+    @Override
+    public TemplateList getAllTemplates(String templateType) throws NotificationClientException {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
+    }
+
+    @Override
+    public TemplatePreview generateTemplatePreview(
+        String templateId,
+        Map<String, String> personalisation
+    ) throws NotificationClientException {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pbis/notify/NotificationClientProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pbis/notify/NotificationClientProviderTest.java
@@ -1,0 +1,82 @@
+package uk.gov.hmcts.reform.pbis.notify;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import uk.gov.hmcts.reform.pbis.ServiceNotFoundException;
+import uk.gov.hmcts.reform.pbis.config.ApplicationConfig;
+import uk.gov.hmcts.reform.pbis.model.EmailTemplateMapping;
+import uk.gov.service.notify.NotificationClient;
+import uk.gov.service.notify.NotificationClientApi;
+
+
+public class NotificationClientProviderTest {
+
+    private static final String SERVICE_1_NAME = "service1";
+    private static final String SERVICE_2_NAME = "service2";
+
+    @Test
+    public void getClient_should_return_stub_when_stub_flag_is_on() {
+        NotificationClientProvider clientProvider = createClientProvider(true);
+
+        NotificationClientApi client = clientProvider.getClient(SERVICE_1_NAME);
+
+        assertThat(client).isExactlyInstanceOf(NotificationClientStub.class);
+    }
+
+    @Test
+    public void getClient_should_return_api_client_when_stub_flag_is_off() {
+        NotificationClientProvider clientProvider = createClientProvider(false);
+
+        NotificationClientApi client = clientProvider.getClient(SERVICE_1_NAME);
+
+        assertThat(client).isInstanceOf(NotificationClient.class);
+    }
+
+    @Test
+    public void getClient_should_return_different_clients_for_different_services() {
+        NotificationClientProvider clientProvider = createClientProvider(false);
+
+        NotificationClientApi clientForService1 = clientProvider.getClient(SERVICE_1_NAME);
+        NotificationClientApi clientForService2 = clientProvider.getClient(SERVICE_2_NAME);
+        assertThat(clientForService2).isNotSameAs(clientForService1);
+    }
+
+    @Test
+    public void getClient_should_return_same_client_for_same_service_each_time() {
+        NotificationClientProvider clientProvider = createClientProvider(false);
+
+        NotificationClientApi client1 = clientProvider.getClient(SERVICE_1_NAME);
+        NotificationClientApi client2 = clientProvider.getClient(SERVICE_1_NAME);
+        assertThat(client2).isSameAs(client1);
+    }
+
+    @Test(expected = ServiceNotFoundException.class)
+    public void getClient_should_throw_exception_when_service_not_configured() {
+        createClientProvider(false).getClient("unknown-service-name");
+    }
+
+    private NotificationClientProvider createClientProvider(boolean useClientStub) {
+        List<EmailTemplateMapping> emailTemplateMappings = Arrays.asList(
+            createTemplateMapping(SERVICE_1_NAME, "apiKey1"),
+            createTemplateMapping(SERVICE_2_NAME, "apiKey2")
+        );
+
+        ApplicationConfig config = mock(ApplicationConfig.class);
+        when(config.getEmailTemplateMappings()).thenReturn(emailTemplateMappings);
+
+        when(config.getUseNotifyClientStub()).thenReturn(useClientStub);
+        return new NotificationClientProvider(config);
+    }
+
+    private static EmailTemplateMapping createTemplateMapping(String service, String apiKey) {
+        EmailTemplateMapping mapping = new EmailTemplateMapping();
+        mapping.setService(service);
+        mapping.setNotifyApiKey(apiKey);
+        return mapping;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pbis/notify/NotificationClientStubTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pbis/notify/NotificationClientStubTest.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.reform.pbis.notify;
+
+import static java.util.Collections.EMPTY_MAP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import uk.gov.service.notify.NotificationClientException;
+import uk.gov.service.notify.SendEmailResponse;
+
+
+public class NotificationClientStubTest {
+
+    private final NotificationClientStub notificationClientStub = new NotificationClientStub();
+
+    @Test
+    public void sendEmail_should_return_null() throws Exception {
+        SendEmailResponse response = notificationClientStub.sendEmail(
+            "template id 123",
+            "email@example.com",
+            EMPTY_MAP,
+            "reference 123"
+        );
+
+        assertThat(response).isNull();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void sendSms_should_throw_UnsupportedOperationException() throws Exception {
+        notificationClientStub.sendSms("", "", EMPTY_MAP, "");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void sendLetter_should_throw_UnsupportedOperationException() throws Exception {
+        notificationClientStub.sendLetter("", EMPTY_MAP, "");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getNotificationById_should_throw_UnsupportedOperationException() throws Exception {
+        notificationClientStub.getNotificationById("");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getNotifications_should_throw_UnsupportedOperationException() throws Exception {
+        notificationClientStub.getNotifications("", "", "", "");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getTemplateById_should_throw_UnsupportedOperationException() throws Exception {
+        notificationClientStub.getTemplateById("");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getTemplateVersion_should_throw_UnsupportedOperationException() throws Exception {
+        notificationClientStub.getTemplateVersion("", 1);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getAllTemplates_should_throw_UnsupportedOperationException() throws Exception {
+        notificationClientStub.getAllTemplates("");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void generateTemplatePreview_should_throw_UnsupportedOperationException()
+        throws Exception {
+
+        notificationClientStub.generateTemplatePreview("", EMPTY_MAP);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-71

### Change description ###

Create GOV.UK Notify client stub and client provider.

The provider is needed to return service-specific clients (using different Notify API keys).

As agreed with Jason, GOV.UK Notify is mocked at the client level.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
