### PR TITLE
Create a stub for Azure Service Bus client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
   compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.1.0'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
+  testCompile group: 'org.assertj', name: 'assertj-core', version: '3.8.0'
   testCompile group: 'org.powermock', name: 'powermock-api-mockito', version: '1.7.3'
   testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '1.7.3'
 }

--- a/src/main/java/uk/gov/hmcts/reform/pbis/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/config/ApplicationConfig.java
@@ -2,8 +2,6 @@ package uk.gov.hmcts.reform.pbis.config;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -14,6 +12,7 @@ import uk.gov.hmcts.reform.pbis.model.EmailTemplateMapping;
 import uk.gov.hmcts.reform.pbis.notify.NotificationClientProvider;
 import uk.gov.hmcts.reform.pbis.servicebus.IServiceBusClientFactory;
 import uk.gov.hmcts.reform.pbis.servicebus.ServiceBusClientFactory;
+import uk.gov.hmcts.reform.pbis.servicebus.ServiceBusClientStub;
 
 
 @Configuration
@@ -55,8 +54,6 @@ public class ApplicationConfig {
     @Bean
     @ConditionalOnProperty(name = "serviceBus.useStub", havingValue = "true")
     public IServiceBusClientFactory getServiceBusClientStubFactory() {
-        return () -> {
-            throw new UnsupportedOperationException("Service client stub not implemented");
-        };
+        return () -> ServiceBusClientStub.getInstance();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientStub.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientStub.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.pbis.servicebus;
+
+import com.microsoft.azure.servicebus.IMessage;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.UUID;
+
+
+public class ServiceBusClientStub implements IServiceBusClient {
+
+    private static final ServiceBusClientStub instance = new ServiceBusClientStub();
+    private Queue<IMessage> messagesToReceive = new LinkedList<>();
+
+    private ServiceBusClientStub() {
+        // hiding default constructor
+    }
+
+    public static ServiceBusClientStub getInstance() {
+        return instance;
+    }
+
+    @Override
+    public IMessage receiveMessage() {
+        return messagesToReceive.poll();
+    }
+
+    @Override
+    public void completeMessage(String messageId, UUID messageLockToken) {
+        // nothing to be done
+    }
+
+    @Override
+    public void close() throws Exception {
+        // nothing to be done
+    }
+
+    public void setMessagesToReceive(Queue<IMessage> messagesToReceive) {
+        this.messagesToReceive = messagesToReceive;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientStubTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientStubTest.java
@@ -1,0 +1,66 @@
+package uk.gov.hmcts.reform.pbis.servicebus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+
+import com.microsoft.azure.servicebus.IMessage;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+
+
+public class ServiceBusClientStubTest {
+
+    private ServiceBusClientStub clientStub = ServiceBusClientStub.getInstance();
+
+
+    @Test
+    public void receiveMessage_should_return_null_when_queue_is_empty() {
+        clientStub.setMessagesToReceive(new LinkedList<>());
+        assertThat(clientStub.receiveMessage()).isNull();
+    }
+
+    @Test
+    public void receiveMessage_should_return_messages_from_queue_until_empty() {
+        List<IMessage> messages = Arrays.asList(
+            mock(IMessage.class),
+            mock(IMessage.class)
+        );
+
+        clientStub.setMessagesToReceive(new LinkedList(messages));
+
+        assertThat(clientStub.receiveMessage()).isSameAs(messages.get(0));
+        assertThat(clientStub.receiveMessage()).isSameAs(messages.get(1));
+        assertThat(clientStub.receiveMessage()).isNull();
+    }
+
+    @Test
+    public void setMessagesToReceive_should_rewrite_message_queue() {
+        List<IMessage> nonEmptyList = Arrays.asList(mock(IMessage.class));
+
+        clientStub.setMessagesToReceive(new LinkedList<>(nonEmptyList));
+        assertThat(clientStub.receiveMessage()).isNotNull();
+
+        clientStub.setMessagesToReceive(new LinkedList<>());
+        assertThat(clientStub.receiveMessage()).isNull();
+
+        clientStub.setMessagesToReceive(new LinkedList<>(nonEmptyList));
+        assertThat(clientStub.receiveMessage()).isNotNull();
+    }
+
+    @Test
+    public void completeMessage_should_not_throw_exception() {
+        assertThatCode(() -> {
+            clientStub.completeMessage("message-id-123", UUID.randomUUID());
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void close_should_not_throw_exception() throws Exception {
+        clientStub.close();
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-70

### Change description ###

Create a stub for Azure Service Bus client. The stub allows for emulating input from Azure Service Bus subscription and will be used by tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
