### PR TITLE
Prepare the application for integration tests

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pbis/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/config/ApplicationConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.pbis.config;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,6 +26,9 @@ public class ApplicationConfig {
     @Value("${serviceBus.connectionString}")
     private String serviceBusConnectionString;
 
+    @Value("${serviceBus.maxReceiveWaitTimeInMs}")
+    private long maxReceiveWaitTimeMs;
+
     private final List<EmailTemplateMapping> emailTemplateMappings = new ArrayList<>();
 
     // this getter is needed by the framework
@@ -45,7 +49,10 @@ public class ApplicationConfig {
     @Bean
     @ConditionalOnProperty(name = "serviceBus.useStub", havingValue = "false")
     public IServiceBusClientFactory getServiceBusClientFactory() {
-        return new ServiceBusClientFactory(serviceBusConnectionString);
+        return new ServiceBusClientFactory(
+            serviceBusConnectionString,
+            Duration.ofMillis(maxReceiveWaitTimeMs)
+        );
     }
 
     @Bean

--- a/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/MessageQueueProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/MessageQueueProcessor.java
@@ -5,6 +5,7 @@ import com.microsoft.azure.servicebus.IMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.pbis.EmailService;
@@ -16,6 +17,7 @@ import uk.gov.hmcts.reform.pbis.model.PrivateBetaRegistration;
  * <p>It reads the whole queue and sends a welcome email based on the content of each message.</p>
  */
 @Service
+@ConditionalOnProperty(value = "scheduling.enable", havingValue = "true", matchIfMissing = true)
 public class MessageQueueProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(MessageQueueProcessor.class);

--- a/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClient.java
@@ -2,21 +2,25 @@ package uk.gov.hmcts.reform.pbis.servicebus;
 
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IMessageReceiver;
+
+import java.time.Duration;
 import java.util.UUID;
 
 
 public class ServiceBusClient implements IServiceBusClient {
 
     private final IMessageReceiver messageReceiver;
+    private final Duration maxReceiveWaitTime;
 
-    public ServiceBusClient(IMessageReceiver messageReceiver) {
+    public ServiceBusClient(IMessageReceiver messageReceiver, Duration maxReceiveWaitTime) {
         this.messageReceiver = messageReceiver;
+        this.maxReceiveWaitTime = maxReceiveWaitTime;
     }
 
     @Override
     public IMessage receiveMessage() {
         try {
-            return this.messageReceiver.receive();
+            return this.messageReceiver.receive(maxReceiveWaitTime);
         } catch (Exception ex) {
             throw new ServiceBusException("Failed to receive message from subscription", ex);
         }

--- a/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientFactory.java
@@ -4,13 +4,17 @@ import com.microsoft.azure.servicebus.ClientFactory;
 import com.microsoft.azure.servicebus.IMessageReceiver;
 import com.microsoft.azure.servicebus.ReceiveMode;
 
+import java.time.Duration;
+
 
 public class ServiceBusClientFactory implements IServiceBusClientFactory {
 
     private final String connectionString;
+    private final Duration maxReceiveWaitTime;
 
-    public ServiceBusClientFactory(String connectionString) {
+    public ServiceBusClientFactory(String connectionString, Duration maxReceiveWaitTime) {
         this.connectionString = connectionString;
+        this.maxReceiveWaitTime = maxReceiveWaitTime;
     }
 
     public IServiceBusClient createClient() {
@@ -20,7 +24,7 @@ public class ServiceBusClientFactory implements IServiceBusClientFactory {
                 ReceiveMode.PEEKLOCK
             );
 
-            return new ServiceBusClient(receiver);
+            return new ServiceBusClient(receiver, maxReceiveWaitTime);
         } catch (Exception e) {
             throw new ServiceBusException("Failed to create Service Bus client", e);
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,5 +12,6 @@ serviceBus:
   useStub: ${SERVICE_BUS_USE_STUB:false}
   connectionString: ${SERVICE_BUS_CONNECTION_STRING:}
   pollingDelayInMs: ${SERVICE_BUS_POLLING_DELAY_MS:30000}
+  maxReceiveWaitTimeInMs: ${SERVICE_BUS_MAX_RECEIVE_WAIT_TIME_MS:30000}
 
 emailTemplateMappings:

--- a/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientFactoryTest.java
@@ -14,6 +14,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 import com.microsoft.azure.servicebus.ClientFactory;
 import com.microsoft.azure.servicebus.IMessageReceiver;
+import java.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,12 +28,13 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class ServiceBusClientFactoryTest {
 
     private static final String CONNECTION_STRING = "connection string";
+    private static final Duration MAX_RECEIVE_TIME = Duration.ofMillis(1);
 
     private ServiceBusClientFactory clientFactory;
 
     @Before
     public void setUp() throws Exception {
-        clientFactory = new ServiceBusClientFactory(CONNECTION_STRING);
+        clientFactory = new ServiceBusClientFactory(CONNECTION_STRING, MAX_RECEIVE_TIME);
 
         mockStatic(ClientFactory.class);
     }
@@ -51,7 +53,7 @@ public class ServiceBusClientFactoryTest {
         // make sure the returned client uses the receiver
         verify(messageReceiver, never()).receive();
         client.receiveMessage();
-        verify(messageReceiver).receive();
+        verify(messageReceiver).receive(MAX_RECEIVE_TIME);
 
         PowerMockito.verifyStatic(ClientFactory.class, times(1));
         ClientFactory.createMessageReceiverFromConnectionString(eq(CONNECTION_STRING), any());

--- a/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IMessageReceiver;
+
+import java.time.Duration;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,6 +24,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ServiceBusClientTest {
 
+    private static final Duration MAX_RECEIVE_TIME = Duration.ofMillis(1);
+
     @Mock
     private IMessageReceiver messageReceiver;
 
@@ -29,16 +33,16 @@ public class ServiceBusClientTest {
 
     @Before
     public void setUp() {
-        client = new ServiceBusClient(messageReceiver);
+        client = new ServiceBusClient(messageReceiver, MAX_RECEIVE_TIME);
     }
 
     @Test
     public void receiveMessage_should_call_receiver() throws Exception {
         IMessage expectedMessage = mock(IMessage.class);
-        given(messageReceiver.receive()).willReturn(expectedMessage);
+        given(messageReceiver.receive(any())).willReturn(expectedMessage);
 
         assertSame(expectedMessage, client.receiveMessage());
-        verify(messageReceiver).receive();
+        verify(messageReceiver).receive(MAX_RECEIVE_TIME);
         verifyNoMoreInteractions(messageReceiver);
     }
 
@@ -47,7 +51,7 @@ public class ServiceBusClientTest {
         Exception expectedCause =
             new com.microsoft.azure.servicebus.primitives.ServiceBusException(true);
 
-        given(messageReceiver.receive()).willThrow(expectedCause);
+        given(messageReceiver.receive(any())).willThrow(expectedCause);
 
         assertThatThrownBy(() -> client.receiveMessage())
             .isInstanceOf(ServiceBusException.class)


### PR DESCRIPTION
### JIRA link (if applicable) ###

Part of the following story:
https://tools.hmcts.net/jira/browse/RPE-91

### Change description ###

Prepare the app for integration tests by:

- configuring the amount time Service Bus client would wait for a new message before returning null to the caller (meaning the subscription is empty)
- making scheduled subscription processing runs conditional, so that they can be turned off in tests (and not interfere with them)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
