### PR TITLE
Add a missing environment variable to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - SERVICE_BUS_POLLING_DELAY_MS
       - SERVICE_BUS_USE_STUB
       - SERVICE_BUS_CONNECTION_STRING
+      - SERVICE_BUS_MAX_RECEIVE_WAIT_TIME_MS
     volumes:
       - ./build/install/private-beta-invitation-service:/opt/app/
     ports:


### PR DESCRIPTION
### Change description ###

Add a missing environment variable (`SERVICE_BUS_MAX_RECEIVE_WAIT_TIME_MS`) to docker-compose.yml

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
