### PR TITLE
Extend Service Bus client to send messages to dead letter queue

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/IServiceBusClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/IServiceBusClient.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.pbis.servicebus;
 
 import com.microsoft.azure.servicebus.IMessage;
 
+import java.util.Map;
 import java.util.UUID;
 
 public interface IServiceBusClient extends AutoCloseable {
@@ -9,4 +10,11 @@ public interface IServiceBusClient extends AutoCloseable {
     IMessage receiveMessage();
 
     void completeMessage(String messageId, UUID messageLockToken);
+
+    void sendToDeadLetter(
+        IMessage message,
+        String reason,
+        String description,
+        Map<String, String> fieldValidationErrors
+    );
 }

--- a/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientStub.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientStub.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.pbis.servicebus;
 import com.microsoft.azure.servicebus.IMessage;
 
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
 
@@ -27,6 +28,16 @@ public class ServiceBusClientStub implements IServiceBusClient {
 
     @Override
     public void completeMessage(String messageId, UUID messageLockToken) {
+        // nothing to be done
+    }
+
+    @Override
+    public void sendToDeadLetter(
+        IMessage message,
+        String reason,
+        String description,
+        Map<String, String> propertiesToModify
+    ) {
         // nothing to be done
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientStubTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClientStubTest.java
@@ -16,7 +16,6 @@ public class ServiceBusClientStubTest {
 
     private ServiceBusClientStub clientStub = ServiceBusClientStub.getInstance();
 
-
     @Test
     public void receiveMessage_should_return_null_when_queue_is_empty() {
         clientStub.setMessagesToReceive(new LinkedList<>());
@@ -55,6 +54,13 @@ public class ServiceBusClientStubTest {
     public void completeMessage_should_not_throw_exception() {
         assertThatCode(() -> {
             clientStub.completeMessage("message-id-123", UUID.randomUUID());
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void sendToDeadLetter_should_not_throw_exception() {
+        assertThatCode(() -> {
+            clientStub.sendToDeadLetter(mock(IMessage.class), "reason", "desc", null);
         }).doesNotThrowAnyException();
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/client/SendToDeadLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/client/SendToDeadLetterTest.java
@@ -1,0 +1,82 @@
+package uk.gov.hmcts.reform.pbis.servicebus.client;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.microsoft.azure.servicebus.IMessage;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import uk.gov.hmcts.reform.pbis.servicebus.ServiceBusException;
+
+
+public class SendToDeadLetterTest extends AbstractServiceBusClientTest {
+
+    @Test
+    public void should_call_receiver_with_right_arguments() throws Exception {
+        String messageId = "messageId123";
+        UUID lockToken = UUID.randomUUID();
+        String reason = "test reason";
+        String description = "test description";
+
+        Map<String, String> fieldValidationErrors = new HashMap<>();
+        fieldValidationErrors.put("field1", "error1");
+        fieldValidationErrors.put("field2", "error2");
+
+        IMessage message = createMessage(messageId, lockToken);
+
+        client.sendToDeadLetter(message, reason, description, fieldValidationErrors);
+
+        verify(messageReceiver).deadLetter(
+            message.getLockToken(),
+            reason,
+            description,
+            convertToMapOfObjects(fieldValidationErrors)
+        );
+
+        verifyNoMoreInteractions(messageReceiver);
+    }
+
+    @Test
+    public void should_fail_when_receiver_fails() throws Exception {
+        String messageId = "message id 123";
+        IMessage message = createMessage(messageId, UUID.randomUUID());
+
+        Exception receiverException = new RuntimeException("test exception", null);
+
+        willThrow(receiverException).given(messageReceiver).deadLetter(any(), any(), any(), any());
+
+        assertThatThrownBy(() ->
+            client.sendToDeadLetter(message, "reason", "description", null)
+        ).isInstanceOf(ServiceBusException.class)
+            .hasCause(receiverException)
+            .hasMessage("Failed to send message to dead letter queue. Message ID: " + messageId);
+    }
+
+    private Map<String, Object> convertToMapOfObjects(Map<String, String> map) {
+        return map
+            .entrySet()
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    Map.Entry::getValue
+                )
+            );
+    }
+
+    private IMessage createMessage(String messageId, UUID lockToken) {
+        IMessage message = mock(IMessage.class);
+        given(message.getMessageId()).willReturn(messageId);
+        given(message.getLockToken()).willReturn(lockToken);
+
+        return message;
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-113

### Change description ###

Extend Service Bus client by a method that sends messages to dead letter queue.

Integration tests will come in a separate pull request for readability.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
