### PR TITLE
Add an integration test for sending messages to dead letter queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ End-to-end tests verify if the service is working as expected by talking to its 
  - `TEST_NOTIFY_API_KEY` - test API key for GOV.UK Notify. This key is used by GOV.UK Notify
  client to authenticate. The client, in term, is used for retrieving information about emails
  that have been sent.
- - `TEST_SERVICE_BUS_CONNECTION_STRING` - connection string to Azure Service Bus,
- including the topic as entity path. This connection string is used for feeding the topic with
- test messages.
+ - `TEST_SERVICE_BUS_CONNECTION_STRING` - connection string to Azure Service Bus namespace
+ (doesn't include entity path). This connection string is used for feeding the topic with
+ test messages - something the service doesn't do
+ - `TEST_SERVICE_BUS_TOPIC` - name of the Azure Service Bus topic the tests feed with data
  - `TEST_SERVICE_BUS_POLLING_DELAY_MS` - the delay, in milliseconds, between consecutive
  Azure Service Bus message processing runs. This is for how long the service may not pick up
  messages from the subscription. Therefore, the tests need to know how long they should wait

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/Configuration.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/Configuration.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.pbis;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import java.time.Duration;
+
 
 public class Configuration {
 
@@ -24,8 +26,16 @@ public class Configuration {
         return config.getString("notify.welcomeLink");
     }
 
-    public String getServiceBusConnectionString() {
-        return config.getString("serviceBus.connectionString");
+    public String getServiceBusNamespaceConnectionString() {
+        return config.getString("serviceBus.namespaceConnectionString");
+    }
+
+    public String getServiceBusTopicName() {
+        return config.getString("serviceBus.topic");
+    }
+
+    public String getServiceBusSubscriptionName() {
+        return config.getString("serviceBus.subscription");
     }
 
     public long getServiceBusPollingDelayInMs() {
@@ -34,5 +44,11 @@ public class Configuration {
 
     public long getMessageLockTimeoutInMs() {
         return config.getLong("serviceBus.messageLockTimeoutInMs");
+    }
+
+    public Duration getMaxReceiveWaitTime() {
+        return Duration.ofMillis(
+            config.getLong("serviceBus.maxReceiveWaitTimeInMs")
+        );
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/categories/EndToEndTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/categories/EndToEndTests.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.pbis.categories;
 
 /**
- * This interface represents a test category - end-to-end tests
+ * This interface represents a test category - end-to-end tests.
  */
 public interface EndToEndTests {
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/categories/IntegrationTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/categories/IntegrationTests.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.pbis.categories;
 
 /**
- * This interface represents a test category - integration tests
+ * This interface represents a test category - integration tests.
  */
 public interface IntegrationTests {
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/EmailServiceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/EmailServiceTest.java
@@ -76,7 +76,7 @@ public class EmailServiceTest {
         PrivateBetaRegistration registrationWithUnknownService =
             SampleData.getSampleRegistration("unknown-service");
 
-        assertThatThrownBy( () ->
+        assertThatThrownBy(() ->
             emailService.sendWelcomeEmail(registrationWithUnknownService)
         )
             .isInstanceOf(EmailSendingException.class)

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/MessageQueueProcessorTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/MessageQueueProcessorTest.java
@@ -157,11 +157,11 @@ public class MessageQueueProcessorTest extends AbstractServiceBusTest {
     }
 
     /**
-     * Prepares a Service Bus client factory spy
+     * Prepares a Service Bus client factory spy.
      *
-     * The spy, instead of an actual client, creates a spy that serves as a proxy
+     * <p>The spy, instead of an actual client, creates a spy that serves as a proxy
      * to the client. This is required so that we can keep track of received messages
-     * and clean them up after tests.
+     * and clean them up after tests.</p>
      */
     private IServiceBusClientFactory prepareServiceBusClientFactorySpy() {
         IServiceBusClientFactory clientFactorySpy = spy(serviceBusClientFactory);
@@ -174,13 +174,13 @@ public class MessageQueueProcessorTest extends AbstractServiceBusTest {
     }
 
     /**
-     * Prepares a Service Bus client spy
+     * Prepares a Service Bus client spy.
      *
-     * The spy calls the actual client, but also keeps track of messages that
+     * <p>The spy calls the actual client, but also keeps track of messages that
      * have been received and not deleted. This allows for deleting those messages
      * after the test. Otherwise messages created in one test could affect
      * results of another test if their lock expires and they reappear
-     * in the subscription.
+     * in the subscription.</p>
      */
     private IServiceBusClient prepareServiceBusClientSpy() throws Exception {
         IServiceBusClient clientSpy = spy(serviceBusClient);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/ServiceBusClientTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/ServiceBusClientTest.java
@@ -125,7 +125,7 @@ public class ServiceBusClientTest extends AbstractServiceBusTest {
         return ImmutableMap.of(
             "DeadLetterReason", reason,
             "DeadLetterErrorDescription", description,
-            "validationErrors", objectMapper.writeValueAsString(validationErrors)
+            "ValidationErrors", objectMapper.writeValueAsString(validationErrors)
         );
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/DeadLetterQueueHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/DeadLetterQueueHelper.java
@@ -6,10 +6,10 @@ import com.microsoft.azure.servicebus.IMessageReceiver;
 import com.microsoft.azure.servicebus.ReceiveMode;
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
 
 public class DeadLetterQueueHelper implements AutoCloseable {
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/DeadLetterQueueHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/DeadLetterQueueHelper.java
@@ -1,0 +1,91 @@
+package uk.gov.hmcts.reform.pbis.utils;
+
+import com.microsoft.azure.servicebus.ClientFactory;
+import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.IMessageReceiver;
+import com.microsoft.azure.servicebus.ReceiveMode;
+import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
+import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+
+public class DeadLetterQueueHelper implements AutoCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeadLetterQueueHelper.class);
+    private final IMessageReceiver messageReceiver;
+    private final Duration maxReceiveWaitTime;
+
+    public DeadLetterQueueHelper(
+        String namespaceConnectionString,
+        String topicName,
+        String subscriptionName,
+        Duration maxReceiveWaitTime) throws ServiceBusException, InterruptedException {
+
+        this.messageReceiver = buildMessageReceiver(
+            namespaceConnectionString,
+            topicName,
+            subscriptionName
+        );
+
+        this.maxReceiveWaitTime = maxReceiveWaitTime;
+    }
+
+    public IMessage receiveMessage() throws ServiceBusException, InterruptedException {
+        logger.info("Receiving message...");
+        IMessage message = messageReceiver.receive(maxReceiveWaitTime);
+
+        if (message != null) {
+            logger.info("Received message with content: {}", new String(message.getBody()));
+        } else {
+            logger.info("Received no message");
+        }
+
+        return message;
+    }
+
+    public void clearDeadLetterQueue() throws ServiceBusException, InterruptedException {
+        logger.info("Clearing dead letter queue...");
+        int deletedMessagesCount = 0;
+
+        IMessage message;
+        while ((message = messageReceiver.receive(maxReceiveWaitTime)) != null) {
+            messageReceiver.complete(message.getLockToken());
+            deletedMessagesCount++;
+        }
+
+        logger.info(
+            "Finished clearing dead letter queue. Deleted messages: {}",
+            deletedMessagesCount
+        );
+    }
+
+    @Override
+    public void close() throws Exception {
+        messageReceiver.close();
+    }
+
+    private IMessageReceiver buildMessageReceiver(
+        String namespaceConnectionString,
+        String topicName,
+        String subscriptionName
+    ) throws InterruptedException, ServiceBusException {
+
+        String deadLetterQueuePath = String.format(
+            "%s/subscriptions/%s/$DeadLetterQueue",
+            topicName,
+            subscriptionName
+        );
+
+        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(
+            namespaceConnectionString,
+            deadLetterQueuePath
+        );
+
+        return ClientFactory.createMessageReceiverFromConnectionStringBuilder(
+            connectionStringBuilder,
+            ReceiveMode.PEEKLOCK
+        );
+    }
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/ServiceBusFeeder.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/ServiceBusFeeder.java
@@ -20,10 +20,13 @@ public class ServiceBusFeeder implements AutoCloseable {
     private final ITopicClient topicClient;
 
     public ServiceBusFeeder(
-        String connectionString
+        String namespaceConnectionString,
+        String subscriptionPath
     ) throws ServiceBusException, InterruptedException {
 
-        topicClient = new TopicClient(new ConnectionStringBuilder(connectionString));
+        topicClient = new TopicClient(
+            new ConnectionStringBuilder(namespaceConnectionString, subscriptionPath)
+        );
     }
 
     public void sendMessages(

--- a/src/functionalTest/resources/environment.conf
+++ b/src/functionalTest/resources/environment.conf
@@ -6,7 +6,10 @@ notify {
 }
 
 serviceBus {
-  connectionString = ${TEST_SERVICE_BUS_CONNECTION_STRING}
+  namespaceConnectionString = ${TEST_SERVICE_BUS_CONNECTION_STRING}
+  topic = ${TEST_SERVICE_BUS_TOPIC}
+  subscription = ${TEST_SERVICE_BUS_SUBSCRIPTION}
   pollingDelayInMs = ${TEST_SERVICE_BUS_POLLING_DELAY_MS}
   messageLockTimeoutInMs = ${TEST_SERVICE_BUS_MESSAGE_LOCK_TIMEOUT_MS}
+  maxReceiveWaitTimeInMs = 500
 }

--- a/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusClient.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 public class ServiceBusClient implements IServiceBusClient {
 
-    private static final String VALIDATION_ERRORS_PROPERTY_KEY = "validationErrors";
+    private static final String VALIDATION_ERRORS_PROPERTY_KEY = "ValidationErrors";
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final IMessageReceiver messageReceiver;

--- a/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/client/SendToDeadLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pbis/servicebus/client/SendToDeadLetterTest.java
@@ -39,7 +39,7 @@ public class SendToDeadLetterTest extends AbstractServiceBusClientTest {
             message.getLockToken(),
             reason,
             description,
-            singletonMap("validationErrors", "{\"field1\":\"error1\",\"field2\":\"error2\"}")
+            singletonMap("ValidationErrors", "{\"field1\":\"error1\",\"field2\":\"error2\"}")
         );
 
         verifyNoMoreInteractions(messageReceiver);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-113

### Change description ###

Add an integration test for Service Bus client - sending messages to dead letter queue.

Adding this integration test required creating a helper for consuming dead letter queue, as well as some tiny changes in other helpers and tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
