### PR TITLE
Send invalid messages straight to dead letter queue

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/AbstractServiceBusTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/AbstractServiceBusTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.pbis.integration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.servicebus.IMessage;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +29,7 @@ import uk.gov.hmcts.reform.pbis.utils.ServiceBusFeeder;
 public abstract class AbstractServiceBusTest {
 
     protected static final Configuration testConfig = new Configuration();
+    protected static final ObjectMapper objectMapper = new ObjectMapper();
     private static final Logger logger = LoggerFactory.getLogger(AbstractServiceBusTest.class);
 
     @Autowired
@@ -112,5 +114,9 @@ public abstract class AbstractServiceBusTest {
             testConfig.getServiceBusSubscriptionName(),
             testConfig.getMaxReceiveWaitTime()
         );
+    }
+
+    protected String bodyAsString(IMessage message) {
+        return new String(message.getBody());
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/MessageQueueProcessorTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/MessageQueueProcessorTest.java
@@ -157,7 +157,7 @@ public class MessageQueueProcessorTest extends AbstractServiceBusTest {
         assertThat(receiveMessage()).as("check if subscription is empty").isNull();
 
         IMessage deadLetterMessage = deadLetterQueueHelper.receiveMessage();
-        assertDeadLetterMessageWithMalformedContent(deadLetterMessage, originalMessage);
+        assertDeadLetterMessageIsForMalformedContent(deadLetterMessage, originalMessage);
 
         assertThat(deadLetterQueueHelper.receiveMessage())
             .as("check if dead letter queue is empty")
@@ -208,7 +208,7 @@ public class MessageQueueProcessorTest extends AbstractServiceBusTest {
             .isEqualTo(expectedProperties);
     }
 
-    private void assertDeadLetterMessageWithMalformedContent(
+    private void assertDeadLetterMessageIsForMalformedContent(
         IMessage deadLetterMessage,
         IMessage originalMessage
     ) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/ServiceBusClientTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/ServiceBusClientTest.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.azure.servicebus.IMessage;
 
@@ -29,7 +28,6 @@ import uk.gov.hmcts.reform.pbis.categories.IntegrationTests;
 @Category(IntegrationTests.class)
 public class ServiceBusClientTest extends AbstractServiceBusTest {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     @Before
@@ -137,7 +135,7 @@ public class ServiceBusClientTest extends AbstractServiceBusTest {
 
         assertThat(message).as("message in dead letter queue").isNotNull();
 
-        assertThat(new String(message.getBody()))
+        assertThat(bodyAsString(message))
             .as("dead letter message content")
             .isEqualTo(expectedContent);
 
@@ -168,10 +166,6 @@ public class ServiceBusClientTest extends AbstractServiceBusTest {
             .stream()
             .map(message -> bodyAsString(message))
             .collect(toList());
-    }
-
-    private String bodyAsString(IMessage message) {
-        return new String(message.getBody());
     }
 
     private void completeMessage(IMessage message) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/DeadLetterQueueHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/DeadLetterQueueHelper.java
@@ -50,7 +50,7 @@ public class DeadLetterQueueHelper implements AutoCloseable {
         int deletedMessagesCount = 0;
 
         IMessage message;
-        while ((message = messageReceiver.receive(maxReceiveWaitTime)) != null) {
+        while ((message = receiveMessage()) != null) {
             messageReceiver.complete(message.getLockToken());
             deletedMessagesCount++;
         }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/SampleData.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/SampleData.java
@@ -31,4 +31,9 @@ public class SampleData {
             "Smith"
         );
     }
+
+    public static PrivateBetaRegistration getSampleInvalidRegistration() {
+        String reference = "pbis-test-" + UUID.randomUUID().toString();
+        return new PrivateBetaRegistration(reference, "", "not-an-email", "", "");
+    }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/ServiceBusFeeder.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/ServiceBusFeeder.java
@@ -2,11 +2,13 @@ package uk.gov.hmcts.reform.pbis.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.ITopicClient;
 import com.microsoft.azure.servicebus.Message;
 import com.microsoft.azure.servicebus.TopicClient;
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.pbis.model.PrivateBetaRegistration;
@@ -54,10 +56,13 @@ public class ServiceBusFeeder implements AutoCloseable {
         );
     }
 
-    public void sendMessage(String content) throws ServiceBusException, InterruptedException {
+    public IMessage sendMessage(String content) throws ServiceBusException, InterruptedException {
         logger.info(String.format("Sending message with content: %s", content));
-        topicClient.send(new Message(content));
+        String messageId = "test-message-" + UUID.randomUUID().toString();
+        IMessage message = new Message(messageId, content, null);
+        topicClient.send(message);
         logger.info(String.format("Sent message with content: %s", content));
+        return message;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/pbis/MessageProcessingResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/MessageProcessingResult.java
@@ -71,18 +71,18 @@ public class MessageProcessingResult {
     public static class ProcessingError {
         public final String reason;
         public final String description;
-        public final Map<String, String> invalidFields;
+        public final Map<String, String> fieldValidationErrors;
         public final Exception exception;
 
         public ProcessingError(
             String reason,
             String description,
-            Map<String, String> invalidFields,
+            Map<String, String> fieldValidationErrors,
             Exception exception
         ) {
             this.reason = reason;
             this.description = description;
-            this.invalidFields = invalidFields;
+            this.fieldValidationErrors = fieldValidationErrors;
             this.exception = exception;
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/MessageQueueProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/MessageQueueProcessor.java
@@ -76,7 +76,7 @@ public class MessageQueueProcessor {
             updateMessageInSubscription(message, processingResult, serviceBusClient);
             logProcessingResult(processingResult, message);
 
-            if (processingResult.resultType == MessageProcessingResultType.SUCCESS) {
+            if (processingResult.resultType != MessageProcessingResultType.SUCCESS) {
                 failureCount++;
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/MessageQueueProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/MessageQueueProcessor.java
@@ -158,8 +158,8 @@ public class MessageQueueProcessor {
         MessageProcessingResult.ProcessingError processingError,
         IMessage message
     ) {
-        String invalidFieldDetails = processingError.invalidFields != null
-            ? " (" + processingError.invalidFields + ")"
+        String invalidFieldDetails = processingError.fieldValidationErrors != null
+            ? " (" + processingError.fieldValidationErrors + ")"
             : "";
 
         logger.warn(


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-113

### Change description ###

When processing Azure Service Bus subscription, the application sends invalid messages straight to dead letter queue now. Before this change, it would treat those cases as general failures and keep giving invalid messages another chance until delivery limit was reached.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
