### PR TITLE
Send a message to dead letter queue if it references an unknown service

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/EmailServiceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/integration/EmailServiceTest.java
@@ -17,8 +17,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.hmcts.reform.pbis.Configuration;
 import uk.gov.hmcts.reform.pbis.EmailCreator;
-import uk.gov.hmcts.reform.pbis.EmailSendingException;
 import uk.gov.hmcts.reform.pbis.EmailService;
+import uk.gov.hmcts.reform.pbis.ServiceNotFoundException;
 import uk.gov.hmcts.reform.pbis.categories.IntegrationTests;
 import uk.gov.hmcts.reform.pbis.model.PrivateBetaRegistration;
 import uk.gov.hmcts.reform.pbis.notify.NotificationClientProvider;
@@ -73,14 +73,21 @@ public class EmailServiceTest {
 
     @Test
     public void sendWelcomeEmail_should_fail_when_service_is_unknown() {
+        String service = "unknown-service";
+
         PrivateBetaRegistration registrationWithUnknownService =
-            SampleData.getSampleRegistration("unknown-service");
+            SampleData.getSampleRegistration(service);
 
         assertThatThrownBy(() ->
             emailService.sendWelcomeEmail(registrationWithUnknownService)
         )
-            .isInstanceOf(EmailSendingException.class)
-            .hasMessageContaining("Failed to send email");
+            .isInstanceOf(ServiceNotFoundException.class)
+            .hasMessageContaining(
+                String.format(
+                    "Service %s not found in email template configuration",
+                    service
+                )
+            );
 
         List<Notification> sentEmails =
             notificationHelper.getSentEmails(registrationWithUnknownService.referenceId);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/ServiceBusFeeder.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/utils/ServiceBusFeeder.java
@@ -40,7 +40,7 @@ public class ServiceBusFeeder implements AutoCloseable {
         }
     }
 
-    public void sendMessage(
+    public IMessage sendMessage(
         PrivateBetaRegistration registration
     ) throws JsonProcessingException, ServiceBusException, InterruptedException {
 
@@ -49,11 +49,13 @@ public class ServiceBusFeeder implements AutoCloseable {
         );
 
         String messageContent = mapper.writeValueAsString(registration);
-        topicClient.send(new Message(messageContent));
+        IMessage message = sendMessage(messageContent);
 
         logger.info(
             String.format("Registration sent. Reference Id: %s", registration.referenceId)
         );
+
+        return message;
     }
 
     public IMessage sendMessage(String content) throws ServiceBusException, InterruptedException {

--- a/src/main/java/uk/gov/hmcts/reform/pbis/EmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/EmailService.java
@@ -43,6 +43,8 @@ public class EmailService {
             logger.info(String.format(
                 "Welcome email sent. Reference ID: %s", privateBetaRegistration.referenceId
             ));
+        } catch (ServiceNotFoundException e) {
+            throw e;
         } catch (Exception e) {
             String errorMessage = String.format(
                 "Failed to send email. Reference ID: %s",

--- a/src/main/java/uk/gov/hmcts/reform/pbis/MessageProcessingResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/MessageProcessingResult.java
@@ -27,7 +27,7 @@ public class MessageProcessingResult {
     public static MessageProcessingResult invalidMessageFormat() {
         return new MessageProcessingResult(
             MessageProcessingResultType.UNPROCESSABLE_MESSAGE,
-            new MessageProcessingResult.ProcessingError(
+            new ProcessingError(
                 "Invalid message",
                 "Message body has invalid format",
                 null,
@@ -41,7 +41,7 @@ public class MessageProcessingResult {
     ) {
         return new MessageProcessingResult(
             MessageProcessingResultType.UNPROCESSABLE_MESSAGE,
-            new MessageProcessingResult.ProcessingError(
+            new ProcessingError(
                 "Invalid message",
                 "Message contains invalid data",
                 getValidationErrorMap(violations),
@@ -53,7 +53,19 @@ public class MessageProcessingResult {
     public static MessageProcessingResult processingError(Exception cause) {
         return new MessageProcessingResult(
             MessageProcessingResultType.ERROR,
-            new MessageProcessingResult.ProcessingError(null, null, null, cause)
+            new ProcessingError(null, null, null, cause)
+        );
+    }
+
+    public static MessageProcessingResult unknownService() {
+        return new MessageProcessingResult(
+            MessageProcessingResultType.UNPROCESSABLE_MESSAGE,
+            new ProcessingError(
+                "Unknown service",
+                "The message references an unknown service",
+                null,
+                null
+            )
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/MessageQueueProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/MessageQueueProcessor.java
@@ -4,6 +4,7 @@ import static uk.gov.hmcts.reform.pbis.MessageProcessingResult.invalidMessageDat
 import static uk.gov.hmcts.reform.pbis.MessageProcessingResult.invalidMessageFormat;
 import static uk.gov.hmcts.reform.pbis.MessageProcessingResult.processingError;
 import static uk.gov.hmcts.reform.pbis.MessageProcessingResult.success;
+import static uk.gov.hmcts.reform.pbis.MessageProcessingResult.unknownService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.servicebus.IMessage;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.pbis.EmailService;
 import uk.gov.hmcts.reform.pbis.MessageProcessingResult;
 import uk.gov.hmcts.reform.pbis.MessageProcessingResultType;
+import uk.gov.hmcts.reform.pbis.ServiceNotFoundException;
 import uk.gov.hmcts.reform.pbis.model.PrivateBetaRegistration;
 
 
@@ -160,6 +162,8 @@ public class MessageQueueProcessor {
         try {
             emailService.sendWelcomeEmail(registration);
             return success();
+        } catch (ServiceNotFoundException e) {
+            return unknownService();
         } catch (Exception e) {
             return processingError(e);
         }

--- a/src/test/java/uk/gov/hmcts/reform/pbis/EmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pbis/EmailServiceTest.java
@@ -117,16 +117,29 @@ public class EmailServiceTest {
     public void sendWelcomeEmail_should_throw_exception_when_client_provider_fails()
         throws NotificationClientException {
 
-        given(
-            notificationClientProvider.getClient(anyString())
-        ).willThrow(
-            new ServiceNotFoundException("test")
-        );
+        Exception thrownException = new RuntimeException("test");
+
+        given(notificationClientProvider.getClient(anyString())).willThrow(thrownException);
 
         assertThatThrownBy(
             () -> emailService.sendWelcomeEmail(privateBetaRegistration)
         ).isInstanceOf(
             EmailSendingException.class
-        );
+        ).hasMessage(
+            "Failed to send email. Reference ID: " + privateBetaRegistration.referenceId
+        ).hasCause(thrownException);
+    }
+
+    @Test()
+    public void sendWelcomeEmail_should_rethrow_exception_when_service_not_found()
+        throws NotificationClientException {
+
+        ServiceNotFoundException exceptionThrown = new ServiceNotFoundException("test");
+
+        given(notificationClientProvider.getClient(anyString())).willThrow(exceptionThrown);
+
+        assertThatThrownBy(
+            () -> emailService.sendWelcomeEmail(privateBetaRegistration)
+        ).isSameAs(exceptionThrown);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-113

### Change description ###

If a message contains a reference to a service (probate/divorce/etc.) that is not present in the application's configuration, that message is sent straight to dead letter queue.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
