### PR TITLE
Update java logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,4 +167,8 @@ sonarqube {
 
 jar {
   baseName 'private-beta-invitation-service'
+
+  manifest {
+    attributes('Implementation-Version': project.version.toString())
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,8 @@ task endToEndTest(type: Test) {
   useJUnit {
     includeCategories 'uk.gov.hmcts.reform.pbis.categories.EndToEndTests'
   }
+
+  environment("APPINSIGHTS_INSTRUMENTATIONKEY", "test-key")
 }
 
 task integrationTest(type: Test) {
@@ -152,6 +154,8 @@ task integrationTest(type: Test) {
   useJUnit {
     includeCategories 'uk.gov.hmcts.reform.pbis.categories.IntegrationTests'
   }
+
+  environment("APPINSIGHTS_INSTRUMENTATIONKEY", "test-key")
 }
 
 project.tasks['sonarqube'].dependsOn test

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ pmd {
 
 def versions = [
   springBoot: '1.5.10.RELEASE',
-  logging: '1.5.0',
+  logging: '2.0.2',
   hystrix: '1.4.2.RELEASE'
 ]
 
@@ -117,7 +117,6 @@ dependencies {
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
   testCompile group: 'org.assertj', name: 'assertj-core', version: '3.9.0'
-  testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.17.1'
   testCompile group: 'org.powermock', name: 'powermock-api-mockito', version: '1.7.3'
   testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '1.7.3'
 
@@ -129,6 +128,10 @@ dependencies {
     'uk.gov.service.notify:notifications-java-client:3.8.0-RELEASE',
     'org.awaitility:awaitility:3.0.0',
   )
+}
+
+test {
+  environment("APPINSIGHTS_INSTRUMENTATIONKEY", "test-key")
 }
 
 task endToEndTest(type: Test) {

--- a/src/main/java/uk/gov/hmcts/reform/pbis/EmailSendingException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/EmailSendingException.java
@@ -1,8 +1,15 @@
 package uk.gov.hmcts.reform.pbis;
 
-public class EmailSendingException extends RuntimeException {
+import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
+
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class EmailSendingException extends UnknownErrorCodeException {
 
     public EmailSendingException(String message, Throwable cause) {
-        super(message, cause);
+        super(AlertLevel.P1, message, cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pbis/ServiceNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/ServiceNotFoundException.java
@@ -1,8 +1,15 @@
 package uk.gov.hmcts.reform.pbis;
 
-public class ServiceNotFoundException extends RuntimeException {
+import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
+
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class ServiceNotFoundException extends UnknownErrorCodeException {
 
     public ServiceNotFoundException(String message) {
-        super(message);
+        super(AlertLevel.P3, message);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pbis/servicebus/ServiceBusException.java
@@ -1,8 +1,15 @@
 package uk.gov.hmcts.reform.pbis.servicebus;
 
-public class ServiceBusException extends RuntimeException {
+import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
+
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class ServiceBusException extends UnknownErrorCodeException {
 
     public ServiceBusException(String message, Throwable cause) {
-        super(message, cause);
+        super(AlertLevel.P1, message, cause);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pbis/ApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pbis/ApplicationTest.java
@@ -1,9 +1,6 @@
 package uk.gov.hmcts.reform.pbis;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
@@ -20,14 +17,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 )
 @SpringBootTest
 public class ApplicationTest {
-
-    @ClassRule
-    public static EnvironmentVariables variables = new EnvironmentVariables();
-
-    @BeforeClass
-    public static void setUp() {
-        variables.set("APPLICATION_INSIGHTS_IKEY", "some-key");
-    }
 
     @Test
     public void contextLoads() {


### PR DESCRIPTION
Fixes:

- Use latest java-logging library and therefore - new AppInsights instrumentation key
  - Move environment set to gradle task since spring boot needs for logback config
  - Remove redundant dependency
- Provide version of application used in AppInsights
- Use helper class for exceptions to prevent doubled logging

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
