### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@ plugins {
   id 'application'
   id 'checkstyle'
   id 'jacoco'
-  id 'io.spring.dependency-management' version '1.0.4.RELEASE'
-  id 'org.springframework.boot' version '1.5.10.RELEASE'
-  id 'org.owasp.dependencycheck' version '2.1.0'
+  id 'io.spring.dependency-management' version '1.0.5.RELEASE'
+  id 'org.springframework.boot' version '1.5.13.RELEASE'
+  id 'org.owasp.dependencycheck' version '3.2.1'
   id 'com.github.ben-manes.versions' version '0.17.0'
   id 'org.sonarqube' version '2.6.1'
   id 'pmd'
@@ -89,9 +89,9 @@ pmd {
 }
 
 def versions = [
-  springBoot: '1.5.10.RELEASE',
+  springBoot: '1.5.13.RELEASE',
   logging: '2.0.2',
-  hystrix: '1.4.2.RELEASE'
+  hystrix: '1.4.4.RELEASE'
 ]
 
 configurations {
@@ -113,7 +113,7 @@ dependencies {
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-hystrix', version: versions.hystrix
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-hystrix-dashboard', version: versions.hystrix
 
-  compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.1.0'
+  compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.5'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
   testCompile group: 'org.assertj', name: 'assertj-core', version: '3.9.0'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -18,4 +18,12 @@
 
   -->
 
+  <suppress>
+    <notes><![CDATA[
+     Does not apply, only used for communication with the service bus.
+    ]]></notes>
+    <gav regex="true">^com\.microsoft\.azure:adal4j:.*$</gav>
+    <cve>CVE-2011-1068</cve>
+  </suppress>
+
 </suppressions>


### PR DESCRIPTION
Previous PR is blocked because of vulnerabilities found by the OWASP dependency check plugin.

This PR updates the dependencies to resolve those issues.
One vulnerability has been suppressed (see comment on code changes).