### PR TITLE
Use codecov instead of codacy for coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,9 @@ cache:
   directories:
   - $HOME/.gradle/caches/
   - $HOME/.gradle/wrapper/
-before_install:
-  - sudo apt-get install jq
-  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
 script:
   - ./gradlew build
   - ./gradlew test
   - ./gradlew jacocoTestReport
 after_success:
-  - java -cp ~/codacy-coverage-reporter-assembly-latest.jar com.codacy.CodacyCoverageReporter -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
As getting the codacy jar fails quite often on Travis.