### PR TITLE
[SKIP-PREVIEW] Fix coverage badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Private Beta Invitation Service
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/7cf5461dde5149338d6029cabe2c6606)](https://www.codacy.com/app/HMCTS/private-beta-invitation-service)
-[![Codacy Badge](https://api.codacy.com/project/badge/Coverage/7cf5461dde5149338d6029cabe2c6606)](https://www.codacy.com/app/HMCTS/private-beta-invitation-service)
+[![codecov](https://codecov.io/gh/hmcts/private-beta-invitation-service/branch/master/graph/badge.svg)](https://codecov.io/gh/hmcts/private-beta-invitation-service)
 [![Build Status](https://travis-ci.org/hmcts/private-beta-invitation-service.svg?branch=master)](https://travis-ci.org/hmcts/private-beta-invitation-service)
 
 This project is a service that sends private beta welcome emails to citizens. It constantly checks if there is


### PR DESCRIPTION
now pointing to codecov instead of old codacy report