### PR TITLE
Read vault uri from module output

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -77,12 +77,6 @@ module "key-vault" {
   product_group_object_id = "38f9dea6-e861-4a50-9e73-21e64f563537"
 }
 
-# used in output
-data "azurerm_key_vault" "vault" {
-  name = "${local.vault_name}"
-  resource_group_name = "${local.vault_rg}"
-}
-
 data "azurerm_key_vault_secret" "test_service_notify_api_key" {
   name = "test-service-notify-api-key"
   vault_uri = "${module.key-vault.key_vault_uri}"

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,5 +1,5 @@
 output "vaultUri" {
-  value = "${data.azurerm_key_vault.vault.vault_uri}"
+  value = "${module.key-vault.key_vault_uri}"
 }
 
 output "vaultName" {


### PR DESCRIPTION
Should hopefully prevent an error in the pipeline on prod:
>data.azurerm_key_vault.vault: data.azurerm_key_vault.vault: KeyVault "pbi-prod" (Resource Group "pbi-prod") does not exist

Also, a bit more clear now I think.