### PR TITLE
Update e2e test

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/pbis/e2e/EndToEndTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pbis/e2e/EndToEndTest.java
@@ -141,7 +141,7 @@ public class EndToEndTest {
             serviceBusFeeder.sendMessage(registration);
         }
 
-        waitForProcessing();
+        registrations.forEach(r -> waitUntilRegistrationIsProcessed(r.referenceId));
 
         List<String> referenceIds = registrations.stream()
             .map(r -> r.referenceId)


### PR DESCRIPTION
E2E tests check whether the notification/email was processed by Gov Notify.

Currently the tests results are rather unpredictable. 
Sometimes they pass, sometimes 1 or 2 emails are not found in Gov Notify (within max wait time).


This change PR changes how long the test waits for the emails to appear in Gov Notify.